### PR TITLE
Cannot see user posts if you are not an accepted follower

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,10 +10,26 @@
   </div>
 </div>
 
-<% @user.own_photos.each do |photo| %>
+<% if current_user.leaders.find_by(username: @user.username) != nil || current_user.id == @user.id %>
+  <% @user.own_photos.each do |photo| %>
+    <div class="row mb-4">
+      <div class="col-md-6 offset-md-3">
+        <%= render "photos/photo", photo: photo %>
+      </div>
+    </div>
+  <% end %>
+<% else %>
+  
   <div class="row mb-4">
     <div class="col-md-6 offset-md-3">
-      <%= render "photos/photo", photo: photo %>
+      <div class="card">
+        <div class="card-body py-3 d-flex align-items-center justify-content-between">
+      
+          <div class="card-body">
+            <p class="card-text">You are not following this user.</p>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
Removes ability to see other users posts if you are not an accepted follower.  If this is the case, adds a card message "You are not following this user."